### PR TITLE
ci: add single final job that can be required for status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,3 +303,18 @@ jobs:
           name: sim
           retention-days: 3
           path: clas12Tags/source/sim.*.hipo
+
+  # finalize
+  #############################################################################
+  final:
+    name: Final
+    needs:
+      - simulation
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: fail
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: exit 1
+      - name: pass
+        run: exit 0


### PR DESCRIPTION
This is so that we don't have to set every matrix element as a required status check.

This new job may be extended to do artifact collection, summaries, deployment, etc.