### PR TITLE
ci: temporarily restrict to a single event generation type

### DIFF
--- a/config/evgen_ci.json
+++ b/config/evgen_ci.json
@@ -1,6 +1,5 @@
 {
   "evgen": [
-    "electronkaon",
-    "electronkaonC"
+    "electronkaon"
   ]
 }

--- a/config/evgen_ci.json
+++ b/config/evgen_ci.json
@@ -1,11 +1,6 @@
 {
   "evgen": [
     "electronkaon",
-    "electronkaonC",
-    "electronneutron",
-    "electrongamma",
-    "electronneutronC",
-    "electronFTkaon",
-    "electrongammaFT"
+    "electronkaonC"
   ]
 }


### PR DESCRIPTION
The CI is getting slow, because there are too many matrix elements trying to run simultaneously. For now, to speed up development, restrict to 1 event generation type.

We can revert this PR later, when we want to run this workflow for real.