### PR TITLE
ci: increase default `num_events`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ env:
       "tag_config_gemc": "latest"
     }
   # default number of events
-  num_events: 10
+  num_events: 500
 
 jobs:
 


### PR DESCRIPTION
Increase the stats a bit so the multiplicity results are believable, but keep the job execution time short.