### PR TITLE
refactor: use upstream repository name in variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,19 @@ on:
       title:
         required: true
         type: string
-      source_url:
+      num_events:
         required: false
         type: string
-      num_events:
+      source_url:
         required: false
         type: string
       git_coatjava:
         required: false
         type: string
-      git_clas12tags:
+      git_clas12Tags:
         required: false
         type: string
-      git_clas12config:
+      git_clas12-config:
         required: false
         type: string
   pull_request:
@@ -49,12 +49,12 @@ env:
       "fork": "JeffersonLab/coatjava",
       "branch": "development"
     }
-  git_clas12tags: >-
+  git_clas12Tags: >-
     {
       "fork": "gemc/clas12Tags",
       "branch": "main"
     }
-  git_clas12config: >-
+  git_clas12-config: >-
     {
       "fork": "c-dilks/clas12-config",
       "branch": "match-latest",
@@ -74,32 +74,32 @@ jobs:
     outputs:
       fork_coatjava: ${{ steps.info.outputs.fork_coatjava }}
       branch_coatjava: ${{ steps.info.outputs.branch_coatjava }}
-      fork_clas12tags: ${{ steps.info.outputs.fork_clas12tags }}
-      branch_clas12tags: ${{ steps.info.outputs.branch_clas12tags }}
-      fork_clas12config: ${{ steps.info.outputs.fork_clas12config }}
-      branch_clas12config: ${{ steps.info.outputs.branch_clas12config }}
+      fork_clas12Tags: ${{ steps.info.outputs.fork_clas12Tags }}
+      branch_clas12Tags: ${{ steps.info.outputs.branch_clas12Tags }}
+      fork_clas12-config: ${{ steps.info.outputs.fork_clas12-config }}
+      branch_clas12-config: ${{ steps.info.outputs.branch_clas12-config }}
       tag_config_coatjava: ${{ steps.info.outputs.tag_config_coatjava }}
       tag_config_gemc: ${{ steps.info.outputs.tag_config_gemc }}
     steps:
       - name: get dependency info
         id: info
         run: |
-          echo fork_coatjava=$(       echo '${{ inputs.git_coatjava || env.git_coatjava }}'         | jq -r '.fork'                ) >> $GITHUB_OUTPUT
-          echo branch_coatjava=$(     echo '${{ inputs.git_coatjava || env.git_coatjava }}'         | jq -r '.branch'              ) >> $GITHUB_OUTPUT
-          echo fork_clas12tags=$(     echo '${{ inputs.git_clas12tags || env.git_clas12tags }}'     | jq -r '.fork'                ) >> $GITHUB_OUTPUT
-          echo branch_clas12tags=$(   echo '${{ inputs.git_clas12tags || env.git_clas12tags }}'     | jq -r '.branch'              ) >> $GITHUB_OUTPUT
-          echo fork_clas12config=$(   echo '${{ inputs.git_clas12config || env.git_clas12config }}' | jq -r '.fork'                ) >> $GITHUB_OUTPUT
-          echo branch_clas12config=$( echo '${{ inputs.git_clas12config || env.git_clas12config }}' | jq -r '.branch'              ) >> $GITHUB_OUTPUT
-          echo tag_config_coatjava=$( echo '${{ inputs.git_clas12config || env.git_clas12config }}' | jq -r '.tag_config_coatjava' ) >> $GITHUB_OUTPUT
-          echo tag_config_gemc=$(     echo '${{ inputs.git_clas12config || env.git_clas12config }}' | jq -r '.tag_config_gemc'     ) >> $GITHUB_OUTPUT
+          echo fork_coatjava=$(        echo '${{ inputs.git_coatjava || env.git_coatjava }}'           | jq -r '.fork'                ) >> $GITHUB_OUTPUT
+          echo branch_coatjava=$(      echo '${{ inputs.git_coatjava || env.git_coatjava }}'           | jq -r '.branch'              ) >> $GITHUB_OUTPUT
+          echo fork_clas12Tags=$(      echo '${{ inputs.git_clas12Tags || env.git_clas12Tags }}'       | jq -r '.fork'                ) >> $GITHUB_OUTPUT
+          echo branch_clas12Tags=$(    echo '${{ inputs.git_clas12Tags || env.git_clas12Tags }}'       | jq -r '.branch'              ) >> $GITHUB_OUTPUT
+          echo fork_clas12-config=$(   echo '${{ inputs.git_clas12-config || env.git_clas12-config }}' | jq -r '.fork'                ) >> $GITHUB_OUTPUT
+          echo branch_clas12-config=$( echo '${{ inputs.git_clas12-config || env.git_clas12-config }}' | jq -r '.branch'              ) >> $GITHUB_OUTPUT
+          echo tag_config_coatjava=$(  echo '${{ inputs.git_clas12-config || env.git_clas12-config }}' | jq -r '.tag_config_coatjava' ) >> $GITHUB_OUTPUT
+          echo tag_config_gemc=$(      echo '${{ inputs.git_clas12-config || env.git_clas12-config }}' | jq -r '.tag_config_gemc'     ) >> $GITHUB_OUTPUT
       - name: dispatch summary
         run: |
           echo '| | | |' >> $GITHUB_STEP_SUMMARY
           echo '| --- | --- | --- |' >> $GITHUB_STEP_SUMMARY
           echo '| **Pull Request** | <${{ inputs.source_url || github.event.pull_request.html_url }}> | ${{ inputs.title || github.event.pull_request.title }} |' >> $GITHUB_STEP_SUMMARY
           echo '| **`coatjava` Fork and Branch** | `${{ steps.info.outputs.fork_coatjava }}` | [`${{ steps.info.outputs.branch_coatjava }}`](https://github.com/${{ steps.info.outputs.fork_coatjava }}/tree/${{ steps.info.outputs.branch_coatjava }}) |' >> $GITHUB_STEP_SUMMARY
-          echo '| **`clas12Tags` Fork and Branch** | `${{ steps.info.outputs.fork_clas12tags }}` | [`${{ steps.info.outputs.branch_clas12tags }}`](https://github.com/${{ steps.info.outputs.fork_clas12tags }}/tree/${{ steps.info.outputs.branch_clas12tags }}) |' >> $GITHUB_STEP_SUMMARY
-          echo '| **`clas12-config` Fork and Branch** | `${{ steps.info.outputs.fork_clas12config }}` | [`${{ steps.info.outputs.branch_clas12config }}`](https://github.com/${{ steps.info.outputs.fork_clas12config }}/tree/${{ steps.info.outputs.branch_clas12config }}) |' >> $GITHUB_STEP_SUMMARY
+          echo '| **`clas12Tags` Fork and Branch** | `${{ steps.info.outputs.fork_clas12Tags }}` | [`${{ steps.info.outputs.branch_clas12Tags }}`](https://github.com/${{ steps.info.outputs.fork_clas12Tags }}/tree/${{ steps.info.outputs.branch_clas12Tags }}) |' >> $GITHUB_STEP_SUMMARY
+          echo '| **`clas12-config` Fork and Branch** | `${{ steps.info.outputs.fork_clas12-config }}` | [`${{ steps.info.outputs.branch_clas12-config }}`](https://github.com/${{ steps.info.outputs.fork_clas12-config }}/tree/${{ steps.info.outputs.branch_clas12-config }}) |' >> $GITHUB_STEP_SUMMARY
           echo '| | | |' >> $GITHUB_STEP_SUMMARY
 
   # build
@@ -139,7 +139,7 @@ jobs:
     container: jeffersonlab/gemc:4.4.2-5.1-5.2-5.3-fedora36-cvmfs ##### FIXME: need `latest` tag
     steps:
       - name: clone
-        run: git clone https://github.com/${{ needs.dependency_info.outputs.fork_clas12tags }}.git --branch ${{ needs.dependency_info.outputs.branch_clas12tags }}
+        run: git clone https://github.com/${{ needs.dependency_info.outputs.fork_clas12Tags }}.git --branch ${{ needs.dependency_info.outputs.branch_clas12Tags }}
       - name: build
         working-directory: clas12Tags/source
         run: |
@@ -178,7 +178,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: clone
-        run: git clone https://github.com/${{ needs.dependency_info.outputs.fork_clas12config }}.git --branch ${{ needs.dependency_info.outputs.branch_clas12config }}
+        run: git clone https://github.com/${{ needs.dependency_info.outputs.fork_clas12-config }}.git --branch ${{ needs.dependency_info.outputs.branch_clas12-config }}
       - name: set number of events
         id: num_events
         run: |


### PR DESCRIPTION
Use the actual repo name instead of some shorter name, or in lower case. This will allow the dispatch triggering workflow to set the payload repo name of the caller.