### PR TITLE
fix: do not set concurrency class to avoid conflict with that of callers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ on:
   schedule:
     - cron: '33 8 * * *'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: false
+# concurrency:
+#   group: ${{ github.head_ref || github.run_id }}
+#   cancel-in-progress: false
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
     - cron: '33 8 * * *'
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: false
 
 defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,10 @@ on:
   schedule:
     - cron: '33 8 * * *'
 
+### keep concurrency class disabled, so that callers can control it
 # concurrency:
 #   group: ${{ github.head_ref || github.run_id }}
-#   cancel-in-progress: false
+#   cancel-in-progress: true
 
 defaults:
   run:


### PR DESCRIPTION
Allow the caller to have full control of the concurrency class.