### PR TITLE
fix: use `evgen` name to set the particle bank for multiplicity analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,19 +452,19 @@ jobs:
       - name: read multiplicity
         run: |
           echo "# Multiplicity Report" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "   config:  PID (multiplicity) ...    # sorted multiplicity for each PID" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '```yaml' >> $GITHUB_STEP_SUMMARY
           for evgen in $(echo '${{ needs.config_files.outputs.matrix_full }}' | jq -r '.evgen[]') ; do
-            echo "### \`$evgen\`" >> $GITHUB_STEP_SUMMARY
+            echo "evgen: $evgen" >> $GITHUB_STEP_SUMMARY
             first=true
             for config in $(echo '${{ needs.config_files.outputs.matrix_full }}' | jq -r '.config[]') ; do
               if $first ; then
-                grep 'multiplicity from' ana.${evgen}.${config}.txt >> $GITHUB_STEP_SUMMARY
-                echo '```' >> $GITHUB_STEP_SUMMARY
+                grep -E '^bank: ' ana.${evgen}.${config}.txt >> $GITHUB_STEP_SUMMARY
+                echo "multiplicity: |" >> $GITHUB_STEP_SUMMARY
+                printf "  %25s:  PID (multiplicity) ...    # sorted multiplicity for each PID\n" "config" >> $GITHUB_STEP_SUMMARY
                 first=false
               fi
-              printf "%25s:  %s" $config "$(tail -n1 ana.${evgen}.${config}.txt)" | xargs -0 -I{} echo {} >> $GITHUB_STEP_SUMMARY
+              printf "  %25s:  %s" $config "$(tail -n1 ana.${evgen}.${config}.txt)" | xargs -0 -I{} echo {} >> $GITHUB_STEP_SUMMARY
             done
-            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
           done
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,11 @@ jobs:
       - name: check if output exists
         run: ls ${{ steps.files.outputs.recFile }}
       - name: analysis
-        run: coatjava/coatjava/bin/run-groovy bin/multiplicity.groovy ${{ steps.files.outputs.recFile }} ${{ steps.files.outputs.anaFile }}
+        run: |
+          bankName="REC::Particle"
+          [[ "${{ matrix.evgen }}" =~ FT ]] && bankName="RECFT::Particle"
+          echo "bankName = $bankName"
+          coatjava/coatjava/bin/run-groovy bin/multiplicity.groovy ${{ steps.files.outputs.recFile }} ${{ steps.files.outputs.anaFile }} $bankName
       - uses: actions/upload-artifact@v3
         with:
           name: sim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,7 @@ jobs:
         run: |
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Configuration Job Matrix:" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
           echo '${{ steps.matrix_full.outputs.matrix_full }}' | jq | xargs -0 -I{} echo {} >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: tar

--- a/bin/multiplicity.groovy
+++ b/bin/multiplicity.groovy
@@ -4,23 +4,21 @@
 import org.jlab.io.hipo.HipoDataSource
 import groovy.json.JsonOutput
 
-def outFile = "multiplicity.txt"
-if(args.length<1) {
+if(args.length<3) {
   System.err.println """
-  USAGE: run-groovy ${this.class.getSimpleName()}.groovy [HIPO file from reconstruction] [output file name (default=$outFile)]
+  USAGE: run-groovy ${this.class.getSimpleName()}.groovy [HIPO file from reconstruction] [output file name] [bank]
   """
   System.exit(101)
 }
 
-def inFile = args[0]
-if(args.length>1) outFile = args[1]
+def inFile           = args[0]
+def outFile          = args[1]
+def particleBankName = args[2]
 def outFileH = new File(outFile)
 def outFileW = outFileH.newWriter(false)
 
 def reader = new HipoDataSource()
 reader.open(inFile)
-
-def particleBankName = inFile.contains(/FT/) ? "RECFT::Particle" : "REC::Particle"
 
 mult = [:]
 while(reader.hasEvent()) {

--- a/bin/multiplicity.groovy
+++ b/bin/multiplicity.groovy
@@ -34,7 +34,7 @@ while(reader.hasEvent()) {
 }
 mult = mult.sort{ -it.value }
 
-outFileW << "multiplicity from `$particleBankName`\n" << JsonOutput.prettyPrint(JsonOutput.toJson(mult)) << '\n'
+outFileW << "bank: $particleBankName\n" << JsonOutput.prettyPrint(JsonOutput.toJson(mult)) << '\n'
 mult.each{ outFileW << sprintf("%14s  ", sprintf("%d (%d)", it.key, it.value)) }
 outFileW << '\n'
 outFileW.close()


### PR DESCRIPTION
Instead of using both `evgen` and `config` names.