### PR TITLE
ci: build with 4 threads, since runners have been upgraded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
       fork_clas12validation: ${{ steps.info.outputs.fork_clas12validation }}
       branch_clas12validation: ${{ steps.info.outputs.branch_clas12validation }}
     steps:
-      - run: nproc ############# TEST
       - name: get dependency info
         id: info
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
       fork_clas12validation: ${{ steps.info.outputs.fork_clas12validation }}
       branch_clas12validation: ${{ steps.info.outputs.branch_clas12validation }}
     steps:
+      - run: nproc ############# TEST
       - name: get dependency info
         id: info
         run: |
@@ -174,7 +175,7 @@ jobs:
           fetch-depth: 0
       - name: build
         working-directory: coatjava
-        run: ./build-coatjava.sh
+        run: ./build-coatjava.sh #-T4 ###FIXME: needs https://github.com/JeffersonLab/coatjava/pull/172
       - name: tree
         run: tree
       - name: tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           fetch-depth: 0
       - name: build
         working-directory: coatjava
-        run: ./build-coatjava.sh #-T4 ###FIXME: needs https://github.com/JeffersonLab/coatjava/pull/172
+        run: ./build-coatjava.sh -T4
       - name: tree
         run: tree
       - name: tar

--- a/bin/ci_build_gemc.sh
+++ b/bin/ci_build_gemc.sh
@@ -9,7 +9,7 @@ fi
 pushd $1
 
 source /app/localSetup.sh
-scons -j2 OPT=1
+scons -j4 OPT=1
 
 module switch gemc/5.3 # for dependency files ##### FIXME: switch to gemc/dev and use ubuntu + cvmfs action
 


### PR DESCRIPTION
GitHub hosted runners have been [upgraded from 2-vCPU to 4-vCPU](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/), so let's make use of the extra power.