### PR TITLE
ci: always `fail-fast`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,7 +399,7 @@ jobs:
       - dependency_info
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix: ${{ fromJson(needs.config_files.outputs.matrix_full) }}
     steps:
       - name: checkout clas12-validation


### PR DESCRIPTION
If it takes a while for a matrix job step to fail, and if the matrix is large, it will take very long for the workflow to report failure, since all jobs will be attempted and there is a limit to the number of parallel-running jobs. This enables `fail-fast` for all job matrices, so that the maximum workflow run time is closer to the maximum allowed job run time.