### PR TITLE
fix: use `wretry.action` for `build_coatjava`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,12 +220,13 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
       - name: build
-        # working-directory: coatjava
         uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # using wretry.action, to mitigate sporadic maven repo connection failures
         with:
-          command: ./build-coatjava.sh -T4
           attempt_limit: 3
           attempt_delay: 10000
+          command: |
+            cd coatjava
+            ./build-coatjava.sh -T4
       - name: tree
         run: tree
       - name: tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
       - name: build
-        working-directory: coatjava
+        # working-directory: coatjava
         uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # using wretry.action, to mitigate sporadic maven repo connection failures
           with:
             command: ./build-coatjava.sh -T4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,9 +224,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 10000
-          command: |
-            cd coatjava
-            ./build-coatjava.sh -T4
+          command: cd coatjava && build-coatjava.sh -T4
       - name: tree
         run: tree
       - name: tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 10000
-          command: 'cd coatjava && build-coatjava.sh -T4'
+          command: 'cd coatjava ; build-coatjava.sh -T4'
       - name: tree
         run: tree
       - name: tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,10 +222,10 @@ jobs:
       - name: build
         working-directory: coatjava
         uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # using wretry.action, to mitigate sporadic maven repo connection failures
-        with:
-          command: ./build-coatjava.sh -T4
-          attempt_limit: 3
-          attempt_delay: 10000
+          with:
+            command: ./build-coatjava.sh -T4
+            attempt_limit: 3
+            attempt_delay: 10000
       - name: tree
         run: tree
       - name: tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
       - name: build
-        working-directory: coatjava
+        # working-directory: coatjava
         uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # using wretry.action, to mitigate sporadic maven repo connection failures
         with:
           command: ./build-coatjava.sh -T4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,8 +224,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 10000
-          command: build-coatjava.sh -T4
-        working-directory: coatjava
+          command: 'cd coatjava ; ./build-coatjava.sh -T4'
       - name: tree
         run: tree
       - name: tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,8 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 10000
-          command: 'cd coatjava ; build-coatjava.sh -T4'
+          command: build-coatjava.sh -T4
+        working-directory: coatjava
       - name: tree
         run: tree
       - name: tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 10000
-          command: cd coatjava && build-coatjava.sh -T4
+          command: 'cd coatjava && build-coatjava.sh -T4'
       - name: tree
         run: tree
       - name: tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,11 @@ jobs:
           fetch-depth: 0
       - name: build
         working-directory: coatjava
-        run: ./build-coatjava.sh -T4
+        uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # using wretry.action, to mitigate sporadic maven repo connection failures
+        with:
+          command: ./build-coatjava.sh -T4
+          attempt_limit: 3
+          attempt_delay: 10000
       - name: tree
         run: tree
       - name: tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,12 +220,12 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
       - name: build
-        # working-directory: coatjava
+        working-directory: coatjava
         uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # using wretry.action, to mitigate sporadic maven repo connection failures
-          with:
-            command: ./build-coatjava.sh -T4
-            attempt_limit: 3
-            attempt_delay: 10000
+        with:
+          command: ./build-coatjava.sh -T4
+          attempt_limit: 3
+          attempt_delay: 10000
       - name: tree
         run: tree
       - name: tar


### PR DESCRIPTION
We've been experiencing sporadic `coatjava` build failures, usually from maven repo connection issues, such as timeouts. Example:
```
2024-02-05T09:06:44.9775242Z [ERROR] Failed to execute goal on project clas12rec: Could not resolve dependencies for project org.jlab.clas:clas12rec:pom:10.0.6-SNAPSHOT: Failed to collect dependencies at org.jlab:groot:jar:4.0.5 -> org.freehep:freehep-jminuit:jar:1.0.2: Failed to read artifact descriptor for org.freehep:freehep-jminuit:jar:1.0.2: Could not transfer artifact org.freehep:freehep-jminuit:pom:1.0.2 from/to freehep-repo-public (https://srs.slac.stanford.edu/nexus/content/groups/freehep-maven2-public/): transfer failed for https://srs.slac.stanford.edu/nexus/content/groups/freehep-maven2-public/org/freehep/freehep-jminuit/1.0.2/freehep-jminuit-1.0.2.pom: Read timed out -> [Help 1]
2024-02-05T09:06:44.9780678Z [ERROR] 
2024-02-05T09:06:44.9781582Z [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
2024-02-05T09:06:44.9782844Z [ERROR] Re-run Maven using the -X switch to enable full debug logging.
2024-02-05T09:06:44.9783620Z [ERROR] 
2024-02-05T09:06:44.9784366Z [ERROR] For more information about the errors and possible solutions, please read the following articles:
2024-02-05T09:06:44.9785925Z [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```
This PR will retry building `coatjava`, to try to avoid such failures showing up in our nightly tests.