### PR TITLE
fix: move `issue_bot`, which requires elevated permissions, to separate workflow

### DIFF
--- a/.github/nightly-issue.md
+++ b/.github/nightly-issue.md
@@ -1,6 +1,4 @@
 ---
-title: Test issue bot on {{ date | date('dddd, MMMM Do, [at] HH:mm[Z]') }}
+title: Nightly validation workflow failed on {{ date | date('dddd, MMMM Do, [at] HH:mm[Z]') }}
 ---
-Ignore this issue.
-
 Workflow Run: {{ env.REPO_URL }}/actions/runs/{{ env.RUN_ID }}

--- a/.github/nightly-issue.md
+++ b/.github/nightly-issue.md
@@ -1,4 +1,6 @@
 ---
-title: Nightly validation workflow failed on {{ date | date('dddd, MMMM Do, [at] HH:mm[Z]') }}
+title: Test issue bot on {{ date | date('dddd, MMMM Do, [at] HH:mm[Z]') }}
 ---
+Ignore this issue.
+
 Workflow Run: {{ env.REPO_URL }}/actions/runs/{{ env.RUN_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
       gemc_executable: ${{ steps.gemc_executable.outputs.gemc_executable }}
       caller_repo: ${{ steps.gemc_executable.outputs.caller_repo }}
     steps:
+      - run: exit 1 # test issue bot response
       - name: checkout clas12-validation
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
     inputs:
       num_events:
-        description: 'override default number of events, both env.num_events_fast and env.num_events_full'
+        description: 'override default number of events'
         required: false
         type: string
       matrix_evgen:
@@ -33,8 +33,6 @@ on:
   push:
     branches: [ main ]
     tags: [ '*' ]
-  schedule:
-    - cron: '33 8 * * *'
 
 # apply cancel-in-progress to:
 # - `pull_request` triggers from the same `head_ref` (PR feature branch) and caller repo (set by `repository_id`)
@@ -48,9 +46,8 @@ defaults:
     shell: bash
 
 env:
-  # default number of events, for "fast" and "full" tests
-  num_events_fast: 10
-  num_events_full: 1000
+  # default number of events
+  num_events: 10
   # default event generation types to run; see below for all available types and their options
   matrix_evgen: >-
     [
@@ -308,11 +305,7 @@ jobs:
       - name: set number of events
         id: num_events
         run: |
-          num_events=${{ inputs.num_events || 0 }} # use custom number of events
-          if [ $num_events -eq 0 ] ; then
-            # use low stats by default, or high stats for nightly scheduled jobs
-            [ "${{ github.event_name }}" = "schedule" ] && num_events=${{ env.num_events_full }} || num_events=${{ env.num_events_fast }}
-          fi
+          num_events=${{ inputs.num_events || env.num_events }}
           echo num_events=$num_events >> $GITHUB_OUTPUT
           echo "### Number of Events:" >> $GITHUB_STEP_SUMMARY
           echo "$num_events" >> $GITHUB_STEP_SUMMARY
@@ -560,22 +553,3 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
           done
           echo '```' >> $GITHUB_STEP_SUMMARY
-
-  issue_bot:
-    name: Issue bot
-    if: ${{ github.event_name == 'schedule' && ( cancelled() || failure() ) }}
-    runs-on: ubuntu-latest
-    needs:
-      - final
-    permissions:
-      contents: read
-      issues: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_URL: ${{ github.event.repository.html_url }}
-          RUN_ID: ${{ github.run_id }}
-        with:
-          filename: .github/nightly-issue.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,6 @@ jobs:
       gemc_executable: ${{ steps.gemc_executable.outputs.gemc_executable }}
       caller_repo: ${{ steps.gemc_executable.outputs.caller_repo }}
     steps:
-      - run: exit 1 # test issue bot response
       - name: checkout clas12-validation
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,31 @@
+name: Scheduled Test
+
+on:
+  schedule:
+    - cron: '33 8 * * *'
+  pull_request: ############### FIXME: remove
+
+jobs:
+
+  validation:
+    uses: ./.github/workflows/ci.yml
+    with:
+      num_events: 7
+
+  issue_bot:
+    name: Issue bot
+    if: ${{ github.event_name == 'schedule' && ( cancelled() || failure() ) }}
+    runs-on: ubuntu-latest
+    needs: [ validation ]
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_URL: ${{ github.event.repository.html_url }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          filename: .github/nightly-issue.md

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -3,19 +3,17 @@ name: Scheduled Test
 on:
   schedule:
     - cron: '33 8 * * *'
-  pull_request: ############### FIXME: remove
 
 jobs:
 
   validation:
     uses: ./.github/workflows/ci.yml
     with:
-      num_events: 7
+      num_events: 1000
 
   issue_bot:
     name: Issue bot
-    # if: ${{ github.event_name == 'schedule' && ( cancelled() || failure() ) }}
-    if: ${{ github.event_name == 'pull_request' && ( cancelled() || failure() ) }}  ###### FIXME
+    if: ${{ github.event_name == 'schedule' && ( cancelled() || failure() ) }}
     runs-on: ubuntu-latest
     needs: [ validation ]
     permissions:

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -14,7 +14,8 @@ jobs:
 
   issue_bot:
     name: Issue bot
-    if: ${{ github.event_name == 'schedule' && ( cancelled() || failure() ) }}
+    # if: ${{ github.event_name == 'schedule' && ( cancelled() || failure() ) }}
+    if: ${{ github.event_name == 'pull_request' && ( cancelled() || failure() ) }}  ###### FIXME
     runs-on: ubuntu-latest
     needs: [ validation ]
     permissions:


### PR DESCRIPTION
Fixes broken Validation callers, e.g. those from https://github.com/JeffersonLab/coatjava/pull/184 (@baltzell)

We only want `issue_bot` to run on `schedule` triggers, so move it to a dedicated workflow which calls the main `ci.yml` workflow, followed by `issue_bot`. This keeps the elevated permission requirement _out_ of the reusable workflow.