### PR TITLE
fix: lock `groovy` version to 4.0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ env:
   # additional settings
   java_version: 17
   java_distribution: zulu
-  groovy_version: 4.x
+  groovy_version: 4.0.3
 
 jobs:
 


### PR DESCRIPTION
Match to the `ifarm` version