### PR TITLE
fix: if `module switch gemc/[highest-tag]` fails, just warn and proceed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
           echo '| | | |' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '- Caller repository: `${{ steps.gemc_executable.outputs.caller_repo }}`' >> $GITHUB_STEP_SUMMARY
-          echo '- GEMC module: `gemc/${{ steps.gemc_module_tag.outputs.gemc_module_tag }}`' >> $GITHUB_STEP_SUMMARY
+          echo '- GEMC module: `gemc/${{ steps.gemc_module_tag.outputs.gemc_module_tag }}`, if available in container; if not, use the default version in the container (see "Run" jobs)' >> $GITHUB_STEP_SUMMARY
           echo '- GEMC executable: `${{ steps.gemc_executable.outputs.gemc_executable }}`' >> $GITHUB_STEP_SUMMARY
 
   # build

--- a/bin/ci_gemc_run.sh
+++ b/bin/ci_gemc_run.sh
@@ -22,10 +22,14 @@ echo "=============================="
 module avail --no-pager
 echo "=============================="
 
-### switch to the gemc module
-### - if we do not have a custom build, this activates the appropriate gemc version
-### - if we do have a custom build, this just makes sure the dependencies are resolved correctly
-module switch gemc/$gemcTag
+### switch the gemc module
+### - if we do not have a custom `gemc` build (e.g, from a `coatjava` trigger),
+###   this activates the version `$gemcTag`, which is likely the highest semver tag
+### - if we do have a custom `gemc` build (e.g., from a `clas12Tags` trigger),
+###   this just makes sure the dependencies are resolved correctly
+### - if this command fails, e.g. if `gemc/$gemcTag` module is not available, a
+###   warning is printed and we proceed with the default version in the container
+module switch gemc/$gemcTag || echo -e "\e[1;31m[WARNING]: proceeding with container's default GEMC version \e[0m" >&2
 
 ### run a simulation
 $gemcExe \

--- a/bin/ci_gemc_run.sh
+++ b/bin/ci_gemc_run.sh
@@ -29,7 +29,9 @@ echo "=============================="
 ###   this just makes sure the dependencies are resolved correctly
 ### - if this command fails, e.g. if `gemc/$gemcTag` module is not available, a
 ###   warning is printed and we proceed with the default version in the container
-module switch gemc/$gemcTag || echo -e "\e[1;31m[WARNING]: proceeding with container's default GEMC version \e[0m" >&2
+module test gemc/$gemcTag &&
+  module switch gemc/$gemcTag ||
+  echo -e "\e[1;31m[WARNING]: proceeding with container's default GEMC version \e[0m" >&2
 
 ### run a simulation
 $gemcExe \


### PR DESCRIPTION
@maureeungaro this PR will mean that validation tests will run with either:
- highest semver tag of `gemc`, if available in the container
- the default `gemc` version in the container, if highest semver is not available

(FYI @baltzell)