### PR TITLE
ci: revert to testing with latest groovy v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ env:
   # additional settings
   java_version: 17
   java_distribution: zulu
-  groovy_version: 4.0.3
+  groovy_version: 4.x
 
 jobs:
 


### PR DESCRIPTION
blocker bug from 4.0.19 is resolved: https://issues.apache.org/jira/browse/GROOVY-11328