### PR TITLE
ci: new scheme for handling GEMC and gcard versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,16 +64,11 @@ env:
       "e_gFT"
     ]
   # default forks and branches; if `ref` is an empty string, the highest semver tag will be used
-  #
-  #########################################################
-  # FIXME: revert clas12-config ref to 'main'
-  #########################################################
-  #
   git_upstream: >-
     {
       "coatjava":          { "fork": "JeffersonLab/coatjava",          "ref": "development" },
       "clas12Tags":        { "fork": "gemc/clas12Tags",                "ref": ""            },
-      "clas12-config":     { "fork": "JeffersonLab/clas12-config",     "ref": "respect-version"        },
+      "clas12-config":     { "fork": "JeffersonLab/clas12-config",     "ref": "main"        },
       "clas12-validation": { "fork": "JeffersonLab/clas12-validation", "ref": "main"        }
     }
   # GEMC version to use in the GEMC container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,16 @@ env:
       "e_gFT"
     ]
   # default forks and branches; if `ref` is an empty string, the highest semver tag will be used
+  #
+  #########################################################
+  # FIXME: revert clas12-config ref to 'main'
+  #########################################################
+  #
   git_upstream: >-
     {
       "coatjava":          { "fork": "JeffersonLab/coatjava",          "ref": "development" },
       "clas12Tags":        { "fork": "gemc/clas12Tags",                "ref": ""            },
-      "clas12-config":     { "fork": "JeffersonLab/clas12-config",     "ref": "main"        },
+      "clas12-config":     { "fork": "JeffersonLab/clas12-config",     "ref": "respect-version"        },
       "clas12-validation": { "fork": "JeffersonLab/clas12-validation", "ref": "main"        }
     }
   # GEMC version to use in the GEMC container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,7 +454,6 @@ jobs:
         run: |
           gemc_module_version=${{ inputs.gemc_version || env.gemc_version }}
           [ "$gemc_module_version" = "match_gcard" ] && gemc_module_version=$(grep -w ${{ matrix.config }} clas12-config/gemc.ver | awk '{print $2}')
-          echo "GEMC VERSION: $gemc_module_version" >> $GITHUB_STEP_SUMMARY
           echo gemc_module_version=$gemc_module_version | tee -a $GITHUB_OUTPUT
       - name: checkout clas12Tags
         if: ${{ steps.gemc_module_version.outputs.gemc_module_version == 'build' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ on:
         description: 'override default forks and refs, env.git_upstream JSON object elements (you do not have to specify all of them, just the ones you want to override)'
         required: false
         type: string
+      gemc_version:
+        description: 'gemc version to use; use "build" to rebuild from clas12Tags, "match_gcard" to use the version matching the gcard, "default" to use the GEMC image default; anything else will use "module switch gemc/gemc_version"'
+        required: false
+        type: string
   pull_request:
   push:
     branches: [ main ]
@@ -67,6 +71,8 @@ env:
       "clas12-config":     { "fork": "JeffersonLab/clas12-config",     "ref": "main"        },
       "clas12-validation": { "fork": "JeffersonLab/clas12-validation", "ref": "main"        }
     }
+  # GEMC version to use in the GEMC container
+  gemc_version: 'match_gcard'
   # default versions of config files
   config_file_versions: >-
     {
@@ -125,9 +131,7 @@ jobs:
       ref_clas12config: ${{ steps.info.outputs.ref_clas12config }}
       fork_clas12validation: ${{ steps.info.outputs.fork_clas12validation }}
       ref_clas12validation: ${{ steps.info.outputs.ref_clas12validation }}
-      gemc_module_tag: ${{ steps.gemc_module_tag.outputs.gemc_module_tag }}
-      gemc_executable: ${{ steps.gemc_executable.outputs.gemc_executable }}
-      caller_repo: ${{ steps.gemc_executable.outputs.caller_repo }}
+      caller_repo: ${{ steps.info.outputs.caller_repo }}
     steps:
       - name: checkout clas12-validation
         uses: actions/checkout@v4
@@ -164,23 +168,8 @@ jobs:
           echo ref_clas12tags=$ref_clas12tags >> $GITHUB_OUTPUT
           echo ref_clas12config=$ref_clas12config >> $GITHUB_OUTPUT
           echo ref_clas12validation=$ref_clas12validation >> $GITHUB_OUTPUT
-      - name: set GEMC module tag
-        id: gemc_module_tag
-        run: |
-          ### if `ref_clas12tags` is a tag, use that; otherwise use the highest semver tag
-          ### FIXME probably won't work for triggers from backports to old `clas12Tags` tags
-          gemc_module_tag=${{ steps.info.outputs.ref_clas12tags }}
-          repo=gemc/clas12Tags
-          bin/is_a_tag.rb $gemc_module_tag $repo || gemc_module_tag=$(bin/get_highest_tag.rb $repo)
-          echo gemc_module_tag=$gemc_module_tag >> $GITHUB_OUTPUT
-      - name: set GEMC executable
-        id: gemc_executable
-        run: |
-          ### if the caller repo is `clas12Tags`, we want to locally build GEMC; if not, use the container version
-          caller_repo=$(echo "${{ github.repository }}" | sed 's;^.*/;;g')
-          [ "$caller_repo" = "clas12Tags" ] && gemc_executable=./clas12Tags/source/gemc || gemc_executable=gemc
-          echo gemc_executable=$gemc_executable >> $GITHUB_OUTPUT
-          echo caller_repo=$caller_repo >> $GITHUB_OUTPUT
+          ### get caller repository
+          echo caller_repo=$(echo "${{ github.repository }}" | sed 's;^.*/;;g') >> $GITHUB_OUTPUT
       - name: dispatch summary
         run: |
           msg=$(echo '${{ github.event.pull_request.title || github.event.head_commit.message }}' | head -n1)
@@ -193,9 +182,7 @@ jobs:
           echo '| **`clas12-validation` Fork and Ref:** | `${{ steps.info.outputs.fork_clas12validation }}` | [`${{ steps.info.outputs.ref_clas12validation }}`](https://github.com/${{ steps.info.outputs.fork_clas12validation }}/tree/${{ steps.info.outputs.ref_clas12validation }}) |' >> $GITHUB_STEP_SUMMARY
           echo '| | | |' >> $GITHUB_STEP_SUMMARY
           echo '' >> $GITHUB_STEP_SUMMARY
-          echo '- Caller repository: `${{ steps.gemc_executable.outputs.caller_repo }}`' >> $GITHUB_STEP_SUMMARY
-          echo '- GEMC module: `gemc/${{ steps.gemc_module_tag.outputs.gemc_module_tag }}`, if available in container; if not, use the default version in the container (see "Run" jobs)' >> $GITHUB_STEP_SUMMARY
-          echo '- GEMC executable: `${{ steps.gemc_executable.outputs.gemc_executable }}`' >> $GITHUB_STEP_SUMMARY
+          echo '- Caller repository: `${{ steps.info.outputs.caller_repo }}`' >> $GITHUB_STEP_SUMMARY
 
   # build
   #############################################################################
@@ -235,6 +222,10 @@ jobs:
           name: build.coatjava
           retention-days: 3
           path: ./*.tar.zst
+
+  #############################################################################################
+  ###### TODO: stopped searchingn for /gemc/ strings here, for cleaning up unused GEMC vars
+  #############################################################################################
 
   build_gemc:
     name: Build GEMC
@@ -448,6 +439,7 @@ jobs:
       fail-fast: true
       matrix: ${{ fromJson(needs.config_files.outputs.matrix_full) }}
     steps:
+      ### setup
       - name: checkout clas12-validation
         uses: actions/checkout@v4
         with:
@@ -478,6 +470,7 @@ jobs:
         run: ls -lhR
       - name: untar build
         run: ls *.tar.zst | xargs -I{} tar xavf {}
+      ### handle config files
       - name: file names
         id: files
         run: |
@@ -491,6 +484,33 @@ jobs:
         run: |
           ls ${{ steps.files.outputs.gemcConfigFile }}
           ls ${{ steps.files.outputs.coatjavaConfigFile }}
+      ### set GEMC version, and rebuild if necessary
+      - name: set GEMC module version
+        id: gemc_version
+        run: |
+          gemc_version=${{ inputs.gemc_version || env.gemc_version }}
+          [ "$gemc_version" = "match_gcard" ] && gemc_version=$(basename $(dirname ${{ steps.files.outputs.gemcConfigFile }}))
+          echo gemc_version=$gemc_version | tee -a $GITHUB_OUTPUT
+  #############################################################################################
+  # TODO: make this gemc rebuild work
+  #############################################################################################
+      - name: checkout clas12Tags
+        if: ${{ steps.gemc_version.outputs.gemc_version == 'build' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.dependency_info.outputs.fork_clas12tags }}
+          ref: ${{ needs.dependency_info.outputs.ref_clas12tags }}
+          path: clas12Tags
+          clean: false
+          fetch-tags: true
+          fetch-depth: 0
+      - name: rebuild GEMC
+        if: ${{ steps.gemc_version.outputs.gemc_version == 'build' }}
+        uses: docker://jeffersonlab/gemc:dev-fedora36
+        with:
+          entrypoint: bin/ci_gemc_build.sh
+          args: clas12Tags/source
+      ### run simulation
       - name: simulation
         uses: docker://jeffersonlab/gemc:dev-fedora36
         with:
@@ -498,12 +518,14 @@ jobs:
           args: ${{ needs.dependency_info.outputs.gemc_executable }} ${{ needs.dependency_info.outputs.gemc_module_tag }} ${{ steps.files.outputs.gemcConfigFile }} ${{ steps.files.outputs.evgenFile }} ${{ steps.files.outputs.simFile }}
       - name: check if output exists
         run: ls ${{ steps.files.outputs.simFile }}
+      ### run reconstruction
       - name: reconstruction
         run: |
           coatjava/coatjava/bin/recon-util \
             -y ${{ steps.files.outputs.coatjavaConfigFile }} \
             -i ${{ steps.files.outputs.simFile }} \
             -o ${{ steps.files.outputs.recFile }}
+      ### handle outputs
       - name: check if output exists
         run: ls ${{ steps.files.outputs.recFile }}
       - name: analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ on:
         required: false
         type: string
       gemc_version:
-        description: 'gemc version to use; use "build" to rebuild from clas12Tags, "match_gcard" to use the version matching the gcard, "default" to use the GEMC image default; anything else will use "module switch gemc/gemc_version"'
+        description: 'gemc version to use; see README.md for details'
         required: false
         type: string
   pull_request:
@@ -223,47 +223,6 @@ jobs:
           retention-days: 3
           path: ./*.tar.zst
 
-  #############################################################################################
-  ###### TODO: stopped searchingn for /gemc/ strings here, for cleaning up unused GEMC vars
-  #############################################################################################
-
-  build_gemc:
-    name: Build GEMC
-    if: ${{ needs.dependency_info.outputs.caller_repo == 'clas12Tags' }} # only build GEMC if triggered by GEMC/clas12Tags
-    needs:
-      - dependency_info
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout clas12-validation
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ needs.dependency_info.outputs.fork_clas12validation }}
-          ref: ${{ needs.dependency_info.outputs.ref_clas12validation }}
-          clean: false
-          fetch-tags: true
-          fetch-depth: 0
-      - name: checkout clas12Tags
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ needs.dependency_info.outputs.fork_clas12tags }}
-          ref: ${{ needs.dependency_info.outputs.ref_clas12tags }}
-          path: clas12Tags
-          clean: false
-          fetch-tags: true
-          fetch-depth: 0
-      - name: build
-        uses: docker://jeffersonlab/gemc:dev-fedora36
-        with:
-          entrypoint: bin/ci_gemc_build.sh
-          args: clas12Tags/source
-      - name: tar
-        run: tar cavf clas12Tags{.tar.zst,}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: build.gemc
-          retention-days: 3
-          path: ./*.tar.zst
-
   # clas12-config configuration
   #############################################################################
 
@@ -346,14 +305,16 @@ jobs:
           for config_file in $(jq -r '.config[]' <(echo '${{ steps.read_matrices.outputs.matrix_config }}')) ; do
             echo "find config files for config='$config_file'"
             if [ "${{ steps.version.outputs.tag_config_coatjava }}" = "latest" ] ; then
-              util/latest.rb coatjava $config_file | tee -a coatjava.ver
+              util/latest.rb coatjava $config_file both | tee -a coatjava.ver
             else
-              ls coatjava/${{ steps.version.outputs.tag_config_coatjava }}/${config_file}.yaml | tee -a coatjava.ver
+              ls   coatjava/${{ steps.version.outputs.tag_config_coatjava }}/${config_file}.yaml
+              echo coatjava/${{ steps.version.outputs.tag_config_coatjava }}/${config_file}.yaml ${{ steps.version.outputs.tag_config_coatjava }} | tee -a coatjava.ver
             fi
             if [ "${{ steps.version.outputs.tag_config_gemc }}" = "latest" ] ; then
-              util/latest.rb gemc $config_file | tee -a gemc.ver
+              util/latest.rb gemc $config_file both | tee -a gemc.ver
             else
-              ls gemc/${{ steps.version.outputs.tag_config_gemc }}/${config_file}.gcard | tee -a gemc.ver
+              ls   gemc/${{ steps.version.outputs.tag_config_gemc }}/${config_file}.gcard
+              echo gemc/${{ steps.version.outputs.tag_config_gemc }}/${config_file}.gcard ${{ steps.version.outputs.tag_config_gemc }} | tee -a gemc.ver
             fi
           done
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -428,10 +389,8 @@ jobs:
   #############################################################################
   fulltest:
     name: Run
-    if: ${{ ! failure() && ! cancelled() }} # needed since `build_gemc` may be skipped
     needs:
       - event_generation
-      - build_gemc
       - config_files
       - dependency_info
     runs-on: ubuntu-latest
@@ -478,24 +437,22 @@ jobs:
           echo simFile=sim.${{ matrix.evgen }}.${{ matrix.config }}.hipo >> $GITHUB_OUTPUT
           echo recFile=rec.${{ matrix.evgen }}.${{ matrix.config }}.hipo >> $GITHUB_OUTPUT
           echo anaFile=ana.${{ matrix.evgen }}.${{ matrix.config }}.txt  >> $GITHUB_OUTPUT
-          echo coatjavaConfigFile=clas12-config/$(grep -w ${{ matrix.config }} clas12-config/coatjava.ver) >> $GITHUB_OUTPUT
-          echo gemcConfigFile=clas12-config/$(grep -w ${{ matrix.config }} clas12-config/gemc.ver) >> $GITHUB_OUTPUT
+          echo coatjavaConfigFile=clas12-config/$(grep -w ${{ matrix.config }} clas12-config/coatjava.ver | awk '{print $1}') >> $GITHUB_OUTPUT
+          echo gemcConfigFile=clas12-config/$(grep -w ${{ matrix.config }} clas12-config/gemc.ver | awk '{print $1}') >> $GITHUB_OUTPUT
       - name: config files exist
         run: |
           ls ${{ steps.files.outputs.gemcConfigFile }}
           ls ${{ steps.files.outputs.coatjavaConfigFile }}
       ### set GEMC version, and rebuild if necessary
       - name: set GEMC module version
-        id: gemc_version
+        id: gemc_module_version
         run: |
-          gemc_version=${{ inputs.gemc_version || env.gemc_version }}
-          [ "$gemc_version" = "match_gcard" ] && gemc_version=$(basename $(dirname ${{ steps.files.outputs.gemcConfigFile }}))
-          echo gemc_version=$gemc_version | tee -a $GITHUB_OUTPUT
-  #############################################################################################
-  # TODO: make this gemc rebuild work
-  #############################################################################################
+          gemc_module_version=${{ inputs.gemc_version || env.gemc_version }}
+          [ "$gemc_module_version" = "match_gcard" ] && gemc_module_version=$(grep -w ${{ matrix.config }} clas12-config/gemc.ver | awk '{print $2}')
+          echo "GEMC VERSION: $gemc_module_version" >> $GITHUB_STEP_SUMMARY
+          echo gemc_module_version=$gemc_module_version | tee -a $GITHUB_OUTPUT
       - name: checkout clas12Tags
-        if: ${{ steps.gemc_version.outputs.gemc_version == 'build' }}
+        if: ${{ steps.gemc_module_version.outputs.gemc_module_version == 'build' }}
         uses: actions/checkout@v4
         with:
           repository: ${{ needs.dependency_info.outputs.fork_clas12tags }}
@@ -505,7 +462,7 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
       - name: rebuild GEMC
-        if: ${{ steps.gemc_version.outputs.gemc_version == 'build' }}
+        if: ${{ steps.gemc_module_version.outputs.gemc_module_version == 'build' }}
         uses: docker://jeffersonlab/gemc:dev-fedora36
         with:
           entrypoint: bin/ci_gemc_build.sh
@@ -515,7 +472,7 @@ jobs:
         uses: docker://jeffersonlab/gemc:dev-fedora36
         with:
           entrypoint: bin/ci_gemc_run.sh
-          args: ${{ needs.dependency_info.outputs.gemc_executable }} ${{ needs.dependency_info.outputs.gemc_module_tag }} ${{ steps.files.outputs.gemcConfigFile }} ${{ steps.files.outputs.evgenFile }} ${{ steps.files.outputs.simFile }}
+          args: ${{ steps.gemc_module_version.outputs.gemc_module_version }} ${{ steps.files.outputs.gemcConfigFile }} ${{ steps.files.outputs.evgenFile }} ${{ steps.files.outputs.simFile }}
       - name: check if output exists
         run: ls ${{ steps.files.outputs.simFile }}
       ### run reconstruction
@@ -554,7 +511,6 @@ jobs:
   #############################################################################
   final:
     name: Final
-    if: ${{ ! failure() && ! cancelled() }} # needed since `build_gemc` may be skipped
     needs:
       - fulltest
       - config_files

--- a/README.md
+++ b/README.md
@@ -70,16 +70,17 @@ Other cases, for example `clas12Tags` triggers, may use a new CI build of `clas1
 
 The following table shows the configuration file versions and repository versions, for various upstream triggering repositories:
 
-| Triggering Repository             | `clas12-config` branch | `gcard` version | `yaml` version     | `gemc` version      | `coatjava` version |
-| ---                               | ---                    | ---             | ---                | ---                 | ---                |
-| `clas12-validation`               | `main`                 | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
-| `coatjava`                        | `main`                 | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | triggering version |
-| `clas12Tags`                      | `dev`                  | `dev`           | latest             | CI build            | `development`      |
-| `clas12-config`, `dev` branch     | `dev`                  | `dev`           | latest             | CI build            | `development`      |
-| `clas12-config`, any other branch | triggering version     | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
+| Triggering Repository                     | `clas12-config` branch | `gcard` version | `yaml` version     | `gemc` version      | `coatjava` version |
+| ---                                       | ---                    | ---             | ---                | ---                 | ---                |
+| `clas12-validation`                       | `main`                 | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
+| `coatjava`                                | `main`                 | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | triggering version |
+| `clas12Tags`                              | `dev`                  | `dev`           | latest             | CI build            | `development`      |
+| `clas12-config`, `dev` branch<sup>3</sup> | `dev`                  | `dev`           | latest             | CI build            | `development`      |
+| `clas12-config`, any other branch         | triggering version     | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
 
 > 1. the latest `yaml` version that _is compatible_ with the `gcard` version.
 > 2. use the `gcard` version to `module switch` to the corresponding `gemc` version
+> 3. or any PR branch that _targets_ the `dev` branch
 
 ## Legacy Version
 The original version of this repository is found in [release `v0.1`](https://github.com/JeffersonLab/clas12-validation/releases/tag/v0.1).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ jobs:
     uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@main
 ```
 
-You may customize the called workflow with `input` variables; in general, they override the `env` variables. Here is an example which describes and uses all of them:
+You may customize the called workflow with `input` variables; in general, they override the `env` variables. Below is an example which describes and uses all of them;
+the default values for all of them [are found in the workflow, in the `env:` section](.github/workflows/ci.yml).
 ```yaml
 jobs:
   validation:
@@ -59,13 +60,13 @@ jobs:
 versions of the configurations (`gcard` files for `gemc`, and `yaml` files for `coatjava`). Depending on the triggering workflow and trigger
 branch, `clas12-validation` needs to choose the most appropriate combination of version numbers.
 
-First of all, the input variable `matrix_config` lists the configuration file (`gcard` and `yaml`) _basenames_ that are tested; for each of these,
-we test the event generator sample defined by `matrix_evgen`. We need the `gcard` version number to match the version of `gemc` that is tested.
-For most triggers, we simply take the highest semantic-version `gcard`, for each `matrix_config` basename, and use the corresponding version of `gemc`;
-on the other hand, for example, `clas12Tags` triggers may use a new build of `clas12Tags` (`gemc`), together with the `dev` version of the `gcard` and
-`yaml` files.
+First of all, the input variable `matrix_config` (see configuration, above) lists the configuration file (`gcard` and `yaml`) _basenames_ that are tested; for each of these,
+we test simulation and reconstruction using the event generator sample defined by `matrix_evgen`.
 
-The table below shows the configuration file versions and the `gemc` version, for each triggering repository:
+In many cases we test on the latest `gcard` for a given basename, but we need to make sure the `gemc` version that is used _matches_ the `gcard` version.
+Other cases, for example `clas12Tags` triggers, may use a new CI build of `clas12Tags` (`gemc`), together with the `dev` version of the `gcard`.
+
+The following table shows the configuration file versions and repository versions, for various upstream triggering repositories:
 
 | Triggering Repository             | `clas12-config` branch | `gcard` version | `yaml` version     | `gemc` version      | `coatjava` version |
 | ---                               | ---                    | ---             | ---                | ---                 | ---                |

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ Other cases, for example `clas12Tags` triggers, may use a new CI build of `clas1
 
 The following table shows the configuration file versions and repository versions, for various upstream triggering repositories:
 
-| Triggering Repository                     | `clas12-config` branch   | `clas12Tags` branch | `gcard` version | `yaml` version     | `gemc` version      | `coatjava` version |
-| ---                                       | ---                      | ---                 | ---             | ---                | ---                 | ---                |
-| `clas12-validation`                       | `main`                   | highest tag         | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
-| `coatjava`                                | `main`                   | highest tag         | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | triggering version |
-| `clas12Tags`                              | `dev`                    | triggering version  | `dev`           | latest             | CI build            | `development`      |
-| `clas12-config`, `dev` branch<sup>3</sup> | `dev` (or triggering PR) | `dev`               | `dev`           | latest             | CI build            | `development`      |
-| `clas12-config`, any other branch         | triggering version       | highest tag         | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
+| Triggering Repository                     | `clas12-config` branch | `clas12Tags` branch | `gcard` version | `yaml` version     | `gemc` version      | `coatjava` version |
+| ---                                       | ---                    | ---                 | ---             | ---                | ---                 | ---                |
+| `clas12-validation`                       | `main`                 | highest tag         | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
+| `coatjava`                                | `main`                 | highest tag         | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | triggering version |
+| `clas12Tags`                              | `dev`                  | triggering version  | `dev`           | latest             | CI build            | `development`      |
+| `clas12-config`, `dev` branch<sup>3</sup> | triggering version     | `dev`               | `dev`           | latest             | CI build            | `development`      |
+| `clas12-config`, any other branch         | triggering version     | highest tag         | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
 
 > 1. the latest `yaml` version that _is compatible_ with the `gcard` version.
 > 2. use the `gcard` version to `module switch` to the corresponding `gemc` version

--- a/README.md
+++ b/README.md
@@ -64,17 +64,16 @@ on the other hand, for example, `clas12Tags` triggers may use a new build of `cl
 
 The table below shows the configuration file versions and the `gemc` version, for each triggering repository:
 
-| Triggering Repository             | `clas12-config` branch | `gcard` version | `yaml` version | `gemc` version | `coatjava` version |
-| ---                               | ---                    | ---             | ---            | ---            | ---                |
-| `clas12-validation`               | `main`                 | latest          | latest[^1]     | `gcard`[^2]    | `development`      |
-| `coatjava`                        | `main`                 | latest          | latest[^1]     | `gcard`[^2]    | triggering version |
-| `clas12Tags`                      | `dev`                  | `dev`           | latest         | CI build       | `development`      |
-| `clas12-config`, `dev` branch     | `dev`                  | `dev`           | latest         | CI build       | `development`      |
-| `clas12-config`, any other branch | triggering version     | latest          | latest[^1]     | `gcard`[^2]    | `development`      |
+| Triggering Repository             | `clas12-config` branch | `gcard` version | `yaml` version     | `gemc` version      | `coatjava` version |
+| ---                               | ---                    | ---             | ---                | ---                 | ---                |
+| `clas12-validation`               | `main`                 | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
+| `coatjava`                        | `main`                 | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | triggering version |
+| `clas12Tags`                      | `dev`                  | `dev`           | latest             | CI build            | `development`      |
+| `clas12-config`, `dev` branch     | `dev`                  | `dev`           | latest             | CI build            | `development`      |
+| `clas12-config`, any other branch | triggering version     | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
 
-[^1] the latest `yaml` version that _is compatible_ with the `gcard` version.
-
-[^2] use the `gcard` version to `module switch` to the corresponding `gemc` version
+> 1. the latest `yaml` version that _is compatible_ with the `gcard` version.
+> 2. use the `gcard` version to `module switch` to the corresponding `gemc` version
 
 ## Legacy Version
 The original version of this repository is found in [release `v0.1`](https://github.com/JeffersonLab/clas12-validation/releases/tag/v0.1).

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ Other cases, for example `clas12Tags` triggers, may use a new CI build of `clas1
 
 The following table shows the configuration file versions and repository versions, for various upstream triggering repositories:
 
-| Triggering Repository                     | `clas12-config` branch   | `gcard` version | `yaml` version     | `gemc` version      | `coatjava` version |
-| ---                                       | ---                      | ---             | ---                | ---                 | ---                |
-| `clas12-validation`                       | `main`                   | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
-| `coatjava`                                | `main`                   | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | triggering version |
-| `clas12Tags`                              | `dev`                    | `dev`           | latest             | CI build            | `development`      |
-| `clas12-config`, `dev` branch<sup>3</sup> | `dev` (or triggering PR) | `dev`           | latest             | CI build            | `development`      |
-| `clas12-config`, any other branch         | triggering version       | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
+| Triggering Repository                     | `clas12-config` branch   | `clas12Tags` branch | `gcard` version | `yaml` version     | `gemc` version      | `coatjava` version |
+| ---                                       | ---                      | ---                 | ---             | ---                | ---                 | ---                |
+| `clas12-validation`                       | `main`                   | highest tag         | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
+| `coatjava`                                | `main`                   | highest tag         | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | triggering version |
+| `clas12Tags`                              | `dev`                    | triggering version  | `dev`           | latest             | CI build            | `development`      |
+| `clas12-config`, `dev` branch<sup>3</sup> | `dev` (or triggering PR) | `dev`               | `dev`           | latest             | CI build            | `development`      |
+| `clas12-config`, any other branch         | triggering version       | highest tag         | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
 
 > 1. the latest `yaml` version that _is compatible_ with the `gcard` version.
 > 2. use the `gcard` version to `module switch` to the corresponding `gemc` version

--- a/README.md
+++ b/README.md
@@ -64,8 +64,17 @@ on the other hand, for example, `clas12Tags` triggers may use a new build of `cl
 
 The table below shows the configuration file versions and the `gemc` version, for each triggering repository:
 
-| Triggering Repository | `clas12-config` branch | `gemc` configuration `gcard` version | `coatjava` configurations `yaml` version | `gemc` version | `coatjava` version |
-| ---                   | ---                    | ---                                  | ---                                      | ---            | ---                |
+| Triggering Repository             | `clas12-config` branch | `gcard` version | `yaml` version | `gemc` version | `coatjava` version |
+| ---                               | ---                    | ---             | ---            | ---            | ---                |
+| `clas12-validation`               | `main`                 | latest          | latest[^1]     | `gcard`[^2]    | `development`      |
+| `coatjava`                        | `main`                 | latest          | latest[^1]     | `gcard`[^2]    | triggering version |
+| `clas12Tags`                      | `dev`                  | `dev`           | latest         | CI build       | `development`      |
+| `clas12-config`, `dev` branch     | `dev`                  | `dev`           | latest         | CI build       | `development`      |
+| `clas12-config`, any other branch | triggering version     | latest          | latest[^1]     | `gcard`[^2]    | `development`      |
+
+[^1] the latest `yaml` version that _is compatible_ with the `gcard` version.
+
+[^2] use the `gcard` version to `module switch` to the corresponding `gemc` version
 
 ## Legacy Version
 The original version of this repository is found in [release `v0.1`](https://github.com/JeffersonLab/clas12-validation/releases/tag/v0.1).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ jobs:
           "coatjava":      { "fork": "UserName/coatjava",          "ref": "feature-branch"   },
           "clas12-config": { "fork": "JeffersonLab/clas12-config", "ref": "new-config-files" }
         }
+      # choose which GEMC version to use, either:
+      # - "build": rebuild GEMC from clas12Tags and use that version
+      # - "match_gcard": use the version matching the gcard
+      # - "default": use the container's default
+      # - anything else will "module switch" to that version
+      gemc_version: match_gcard
 ```
 
 ## Version Handling

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ First of all, the input variable `matrix_config` (see configuration, above) list
 we test simulation and reconstruction using the event generator sample defined by `matrix_evgen`.
 
 In many cases we test on the latest `gcard` for a given basename, but we need to make sure the `gemc` version that is used _matches_ the `gcard` version.
+The latest version of a `gcard` (or `yaml`) file for a given basename is determined by finding all of the `gcard` (or `yaml`) files with that
+basename, and choosing the one in the subdirectory corresponding to the highest semantic version number.
 Other cases, for example `clas12Tags` triggers, may use a new CI build of `clas12Tags` (`gemc`), together with the `dev` version of the `gcard`.
 
 The following table shows the configuration file versions and repository versions, for various upstream triggering repositories:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Automated validation of CLAS12 offline software using GitHub Continuous Integrat
 - [`coatjava`](https://github.com/JeffersonLab/coatjava)
 - [`gemc`](https://github.com/gemc), namely [`clas12Tags`](https://github.com/gemc/clas12Tags)
 - [`clas12-config`](https://github.com/JeffersonLab/clas12-config)
+- this repository itself
+
+## Configuration
 
 The [workflow](.github/workflows/ci.yml) is reusable: it can be called by other workflows as
 ```yaml

--- a/README.md
+++ b/README.md
@@ -50,5 +50,22 @@ jobs:
         }
 ```
 
-### Legacy Version
+## Version Handling
+
+`clas12-validation` supports certain version combinations, with versions of the upstream repositories (`clas12Tags`, `coatjava`, _etc_.) and
+versions of the configurations (`gcard` files for `gemc`, and `yaml` files for `coatjava`). Depending on the triggering workflow and trigger
+branch, `clas12-validation` needs to choose the most appropriate combination of version numbers.
+
+First of all, the input variable `matrix_config` lists the configuration file (`gcard` and `yaml`) _basenames_ that are tested; for each of these,
+we test the event generator sample defined by `matrix_evgen`. We need the `gcard` version number to match the version of `gemc` that is tested.
+For most triggers, we simply take the highest semantic-version `gcard`, for each `matrix_config` basename, and use the corresponding version of `gemc`;
+on the other hand, for example, `clas12Tags` triggers may use a new build of `clas12Tags` (`gemc`), together with the `dev` version of the `gcard` and
+`yaml` files.
+
+The table below shows the configuration file versions and the `gemc` version, for each triggering repository:
+
+| Triggering Repository | `clas12-config` branch | `gemc` configuration `gcard` version | `coatjava` configurations `yaml` version | `gemc` version | `coatjava` version |
+| ---                   | ---                    | ---                                  | ---                                      | ---            | ---                |
+
+## Legacy Version
 The original version of this repository is found in [release `v0.1`](https://github.com/JeffersonLab/clas12-validation/releases/tag/v0.1).

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Other cases, for example `clas12Tags` triggers, may use a new CI build of `clas1
 
 The following table shows the configuration file versions and repository versions, for various upstream triggering repositories:
 
-| Triggering Repository                     | `clas12-config` branch | `gcard` version | `yaml` version     | `gemc` version      | `coatjava` version |
-| ---                                       | ---                    | ---             | ---                | ---                 | ---                |
-| `clas12-validation`                       | `main`                 | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
-| `coatjava`                                | `main`                 | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | triggering version |
-| `clas12Tags`                              | `dev`                  | `dev`           | latest             | CI build            | `development`      |
-| `clas12-config`, `dev` branch<sup>3</sup> | `dev`                  | `dev`           | latest             | CI build            | `development`      |
-| `clas12-config`, any other branch         | triggering version     | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
+| Triggering Repository                     | `clas12-config` branch   | `gcard` version | `yaml` version     | `gemc` version      | `coatjava` version |
+| ---                                       | ---                      | ---             | ---                | ---                 | ---                |
+| `clas12-validation`                       | `main`                   | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
+| `coatjava`                                | `main`                   | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | triggering version |
+| `clas12Tags`                              | `dev`                    | `dev`           | latest             | CI build            | `development`      |
+| `clas12-config`, `dev` branch<sup>3</sup> | `dev` (or triggering PR) | `dev`           | latest             | CI build            | `development`      |
+| `clas12-config`, any other branch         | triggering version       | latest          | latest<sup>1</sup> | `gcard`<sup>2</sup> | `development`      |
 
 > 1. the latest `yaml` version that _is compatible_ with the `gcard` version.
 > 2. use the `gcard` version to `module switch` to the corresponding `gemc` version

--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ The latest version of a `gcard` (or `yaml`) file for a given basename is determi
 basename, and choosing the one in the subdirectory corresponding to the highest semantic version number.
 Other cases, for example `clas12Tags` triggers, may use a new CI build of `clas12Tags` (`gemc`), together with the `dev` version of the `gcard`.
 
-The following table shows the configuration file versions and repository versions, for various upstream triggering repositories:
+The following table shows the configuration file versions and repository versions, for various upstream triggering repositories.
+
+> [!NOTE]
+> This table may not be up-to-date! Check the repositories' CI configurations for the actual versions used.
 
 | Triggering Repository                     | `clas12-config` branch | `clas12Tags` branch | `gcard` version | `yaml` version     | `gemc` version      | `coatjava` version |
 | ---                                       | ---                    | ---                 | ---             | ---                | ---                 | ---                |

--- a/bin/ci_gemc_build.sh
+++ b/bin/ci_gemc_build.sh
@@ -11,13 +11,6 @@ set +u
 source /etc/profile.d/localSetup.sh
 set -u
 
-### show available modules
-echo "=============================="
-echo "MODULE AVAIL"
-echo "=============================="
-module avail --no-pager
-echo "=============================="
-
 ### compile GEMC in $sourceDir
 pushd $sourceDir
 scons -j$(nproc) OPT=1

--- a/bin/ci_gemc_run.sh
+++ b/bin/ci_gemc_run.sh
@@ -4,36 +4,34 @@
 set -e
 set -u
 
-gemcExe=$1
-gemcTag=$2
-gemcConfigFile=$3
-evgenFile=$4
-simFile=$5
+gemcVer=$1
+gemcConfigFile=$2
+evgenFile=$3
+simFile=$4
 
 ### source environment
 set +u
 source /etc/profile.d/localSetup.sh
 set -u
 
-### show available modules
-echo "=============================="
-echo "MODULE AVAIL"
-echo "=============================="
-module avail --no-pager
-echo "=============================="
-
-### switch the gemc module
-### - if we do not have a custom `gemc` build (e.g, from a `coatjava` trigger),
-###   use whatever the container's default version is
-### - if we do have a custom `gemc` build (e.g., from a `clas12Tags` trigger),
-###   this just makes sure the dependencies are resolved correctly
-### - if this command fails, e.g. if `gemc/$gemcTag` module is not available, a
-###   warning is printed and we proceed with the default version in the container
-if [ "$gemcExe" != "gemc" ]; then
-  module test gemc/$gemcTag &&
-    module switch gemc/$gemcTag ||
-    echo -e "\e[1;31m[WARNING]: proceeding with container's default GEMC version \e[0m" >&2
-fi
+### switch the gemc module, or use the CI build
+gemcExe=gemc
+case $gemcVer in
+  build)
+    gemcExe=./clas12Tags/source/gemc
+    ;;
+  default)
+    ;;
+  *)
+    echo '''
+    ==============================
+    MODULE AVAIL
+    =============================='''
+    module avail --no-pager
+    echo '=============================='
+    module switch gemc/$gemcVer
+    ;;
+esac
 
 ### run a simulation
 $gemcExe \


### PR DESCRIPTION
Closes #146 

The `dev` branches on `clas12Tags` and `clas12-config` have required some thought about choosing the correct versions of `gcards` and `gemc`. This PR:
- adds a table, showing what versions _should_ be used for each case
- handles `gemc` module switching more generally