### PR TITLE
ci: allow for choice of GEMC image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,12 @@ on:
       git_upstream:
         required: false
         type: string
-      gemc_version:
-        required: false
-        type: string
       gemc_image:
         required: false
         type: string
-        default: 'docker://jeffersonlab/gemc:dev-fedora36'
+      gemc_version:
+        required: false
+        type: string
       matrix_config:
         required: false
         type: string
@@ -87,6 +86,12 @@ env:
       "clas12-config":     { "fork": "JeffersonLab/clas12-config",     "ref": "main"        },
       "clas12-validation": { "fork": "JeffersonLab/clas12-validation", "ref": "main"        }
     }
+
+  # GEMC Docker image to use; unfortunately we cannot simply pass the image
+  # name to the CI job step, so instead we have the following aliases:
+  # - "fedora": docker://jeffersonlab/gemc:dev-fedora36
+  # - "alma":   docker://jeffersonlab/gemc:dev-almalinux93
+  gemc_image: 'fedora'
 
   # GEMC version to use in the GEMC container; available choices:
   # - "build":        rebuild GEMC from clas12Tags and use that version
@@ -479,15 +484,16 @@ jobs:
         run: |
           ls ${{ steps.files.outputs.gemcConfigFile }}
           ls ${{ steps.files.outputs.coatjavaConfigFile }}
-      ### set GEMC version, and rebuild if necessary
-      - name: set GEMC module version
-        id: gemc_module_version
+      ### set GEMC version and image, and rebuild if necessary
+      - name: set GEMC versioning
+        id: gemc_ver
         run: |
           gemc_module_version=${{ inputs.gemc_version || env.gemc_version }}
           [ "$gemc_module_version" = "match_gcard" ] && gemc_module_version=$(grep -w ${{ matrix.config }} clas12-config/gemc.ver | awk '{print $2}')
           echo gemc_module_version=$gemc_module_version | tee -a $GITHUB_OUTPUT
+          echo gemc_image=${{ inputs.gemc_image || env.gemc_image }} | tee -a $GITHUB_OUTPUT
       - name: checkout clas12Tags
-        if: ${{ steps.gemc_module_version.outputs.gemc_module_version == 'build' }}
+        if: ${{ steps.gemc_ver.outputs.gemc_module_version == 'build' }}
         uses: actions/checkout@v4
         with:
           repository: ${{ needs.dependency_info.outputs.fork_clas12tags }}
@@ -496,18 +502,31 @@ jobs:
           clean: false
           fetch-tags: true
           fetch-depth: 0
-      - name: rebuild GEMC
-        if: ${{ steps.gemc_module_version.outputs.gemc_module_version == 'build' }}
-        uses: ${{ inputs.gemc_image }}
+      - name: rebuild GEMC - fedora ### fedora build
+        if: ${{ steps.gemc_ver.outputs.gemc_image == 'fedora' && steps.gemc_ver.outputs.gemc_module_version == 'build' }}
+        uses: docker://jeffersonlab/gemc:dev-fedora36
+        with:
+          entrypoint: bin/ci_gemc_build.sh
+          args: clas12Tags/source
+      - name: rebuild GEMC - alma ### alma build
+        if: ${{ steps.gemc_ver.outputs.gemc_image == 'alma' && steps.gemc_ver.outputs.gemc_module_version == 'build' }}
+        uses: docker://jeffersonlab/gemc:dev-almalinux93
         with:
           entrypoint: bin/ci_gemc_build.sh
           args: clas12Tags/source
       ### run simulation
-      - name: simulation
-        uses: ${{ inputs.gemc_image }}
+      - name: simulation ### fedora build
+        if: ${{ steps.gemc_ver.outputs.gemc_image == 'fedora' }}
+        uses: docker://jeffersonlab/gemc:dev-fedora36
         with:
           entrypoint: bin/ci_gemc_run.sh
-          args: ${{ steps.gemc_module_version.outputs.gemc_module_version }} ${{ steps.files.outputs.gemcConfigFile }} ${{ steps.files.outputs.evgenFile }} ${{ steps.files.outputs.simFile }}
+          args: ${{ steps.gemc_ver.outputs.gemc_module_version }} ${{ steps.files.outputs.gemcConfigFile }} ${{ steps.files.outputs.evgenFile }} ${{ steps.files.outputs.simFile }}
+      - name: simulation ### alma build
+        if: ${{ steps.gemc_ver.outputs.gemc_image == 'alma' }}
+        uses: docker://jeffersonlab/gemc:dev-almalinux93
+        with:
+          entrypoint: bin/ci_gemc_run.sh
+          args: ${{ steps.gemc_ver.outputs.gemc_module_version }} ${{ steps.files.outputs.gemcConfigFile }} ${{ steps.files.outputs.evgenFile }} ${{ steps.files.outputs.simFile }}
       - name: check if output exists
         run: ls ${{ steps.files.outputs.simFile }}
       ### run reconstruction

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ on:
       gemc_version:
         required: false
         type: string
+      gemc_image:
+        required: false
+        type: string
+        default: 'docker://jeffersonlab/gemc:dev-fedora36'
       matrix_config:
         required: false
         type: string
@@ -494,13 +498,13 @@ jobs:
           fetch-depth: 0
       - name: rebuild GEMC
         if: ${{ steps.gemc_module_version.outputs.gemc_module_version == 'build' }}
-        uses: docker://jeffersonlab/gemc:dev-fedora36
+        uses: ${{ inputs.gemc_image }}
         with:
           entrypoint: bin/ci_gemc_build.sh
           args: clas12Tags/source
       ### run simulation
       - name: simulation
-        uses: docker://jeffersonlab/gemc:dev-fedora36
+        uses: ${{ inputs.gemc_image }}
         with:
           entrypoint: bin/ci_gemc_run.sh
           args: ${{ steps.gemc_module_version.outputs.gemc_module_version }} ${{ steps.files.outputs.gemcConfigFile }} ${{ steps.files.outputs.evgenFile }} ${{ steps.files.outputs.simFile }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ env:
   # name to the CI job step, so instead we have the following aliases:
   # - "fedora": docker://jeffersonlab/gemc:dev-fedora36
   # - "alma":   docker://jeffersonlab/gemc:dev-almalinux93
-  gemc_image: 'fedora'
+  gemc_image: 'alma'
 
   # GEMC version to use in the GEMC container; available choices:
   # - "build":        rebuild GEMC from clas12Tags and use that version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ env:
   # name to the CI job step, so instead we have the following aliases:
   # - "fedora": docker://jeffersonlab/gemc:dev-fedora36
   # - "alma":   docker://jeffersonlab/gemc:dev-almalinux93
-  gemc_image: 'alma'
+  gemc_image: 'fedora'
 
   # GEMC version to use in the GEMC container; available choices:
   # - "build":        rebuild GEMC from clas12Tags and use that version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,13 +515,13 @@ jobs:
           entrypoint: bin/ci_gemc_build.sh
           args: clas12Tags/source
       ### run simulation
-      - name: simulation ### fedora build
+      - name: simulation - fedora ### fedora build
         if: ${{ steps.gemc_ver.outputs.gemc_image == 'fedora' }}
         uses: docker://jeffersonlab/gemc:dev-fedora36
         with:
           entrypoint: bin/ci_gemc_run.sh
           args: ${{ steps.gemc_ver.outputs.gemc_module_version }} ${{ steps.files.outputs.gemcConfigFile }} ${{ steps.files.outputs.evgenFile }} ${{ steps.files.outputs.simFile }}
-      - name: simulation ### alma build
+      - name: simulation - alma ### alma build
         if: ${{ steps.gemc_ver.outputs.gemc_image == 'alma' }}
         uses: docker://jeffersonlab/gemc:dev-almalinux93
         with:


### PR DESCRIPTION
Adds input variable `gemc_image` to choose the Docker image for GEMC:

unfortunately we cannot simply pass the image name to the CI job step, so instead we have the following aliases:
- "fedora": docker://jeffersonlab/gemc:dev-fedora36
- "alma":   docker://jeffersonlab/gemc:dev-almalinux93
