### PR TITLE
ci: scheduled tests are now twice per week instead of nightly

### DIFF
--- a/.github/nightly-issue.md
+++ b/.github/nightly-issue.md
@@ -1,4 +1,0 @@
----
-title: Nightly validation workflow failed on {{ date | date('dddd, MMMM Do, [at] HH:mm[Z]') }}
----
-Workflow Run: {{ env.REPO_URL }}/actions/runs/{{ env.RUN_ID }}

--- a/.github/scheduled-issue.md
+++ b/.github/scheduled-issue.md
@@ -1,0 +1,4 @@
+---
+title: Scheduled validation workflow failed on {{ date | date('dddd, MMMM Do, [at] HH:mm[Z]') }}
+---
+Workflow Run: {{ env.REPO_URL }}/actions/runs/{{ env.RUN_ID }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -2,7 +2,8 @@ name: Scheduled Test
 
 on:
   schedule:
-    - cron: '33 8 * * *'
+    # Wednesday and Saturday at 0830Z
+    - cron: '30 8 * * 3,6'
 
 jobs:
 
@@ -27,4 +28,4 @@ jobs:
           REPO_URL: ${{ github.event.repository.html_url }}
           RUN_ID: ${{ github.run_id }}
         with:
-          filename: .github/nightly-issue.md
+          filename: .github/scheduled-issue.md


### PR DESCRIPTION
Nightly seems a bit too frequent, compared to the rate of change on our production branches; furthermore, when this high-statistics job is running, my (our?) other workflow runs on other `JeffersonLab`-owned repos are queued and have to wait for this one.

The new run times are Wednesday and Saturday at 03:30 EST / 04:30 EDT (=0830Z).

FYI @baltzell, @maureeungaro, @raffaelladevita 