### PR TITLE
ci: reduce default job matrix size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,16 @@ env:
   matrix_evgen: >-
     [
       "e_K",
-      "e_KC",
-      "e_n",
-      "e_g",
-      "e_nC",
-      "eFT_K",
-      "e_gFT"
+      "e_g"
+    ]
+
+  # list of configuration file basenames to test; these configuration files
+  # are the basenames of the 'yaml' and 'gcard' files from `clas12-config`
+  matrix_config: >-
+    [
+      "rga_fall2018",
+      "rgb_fall2019",
+      "rgk_fall2018_FTOn"
     ]
 
   # forks and branches (`ref`s) of the involved git repositories;
@@ -99,18 +103,6 @@ env:
   # - "default":      use the container's default
   # - anything else:  will "module switch" to that version
   gemc_version: 'match_gcard'
-
-  # list of configuration file basenames to test; these configuration files
-  # are the 'yaml' and 'gcard' files from `clas12-config`
-  matrix_config: >-
-    [
-      "clas12-default",
-      "rga_spring2018",
-      "rga_fall2018",
-      "rgk_fall2018_FTOn",
-      "rgb_fall2019",
-      "rgc_summer2022"
-    ]
 
   # versions of config files from `matrix_config`;
   # use "latest" for the highest semantic version

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -11,6 +11,25 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       num_events: 1000
+      matrix_evgen: >-
+        [
+          "e_K",
+          "e_KC",
+          "e_n",
+          "e_g",
+          "e_nC",
+          "eFT_K",
+          "e_gFT"
+        ]
+      matrix_config: >-
+        [
+          "clas12-default",
+          "rga_spring2018",
+          "rga_fall2018",
+          "rgk_fall2018_FTOn",
+          "rgb_fall2019",
+          "rgc_summer2022"
+        ]
 
   issue_bot:
     name: Issue bot


### PR DESCRIPTION
- keep scheduled workflow's job matrix the same
- reduce default job matrix, which is triggered on PRs, pushes to `main`, and callers' default