### PR TITLE
ci: don't print download progress when building `coatjava`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
         with:
           attempt_limit: 3
           attempt_delay: 10000
-          command: 'cd coatjava ; ./build-coatjava.sh -T4'
+          command: 'cd coatjava ; ./build-coatjava.sh --no-progress -T4'
       - name: tree
         run: tree
       - name: tar


### PR DESCRIPTION
for less noisy logs